### PR TITLE
fix: update pages to include published version when using production

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -7,7 +7,7 @@ export async function getStaticPaths() {
   const storyblokApi = useStoryblokApi()
 
   const { data } = await storyblokApi.get('cdn/links', {
-    version: 'draft',
+    version: import.meta.env.DEV ? 'draft' : 'published',
   })
   let links = data.links
   links = Object.values(links)
@@ -28,7 +28,7 @@ const storyblokApi = useStoryblokApi()
 const { data } = await storyblokApi.get(
   `cdn/stories/${slug === undefined ? 'home' : slug}`,
   {
-    version: 'draft',
+    version: import.meta.env.DEV ? 'draft' : 'published',
   }
 )
 


### PR DESCRIPTION
Hey there!

This PR changes the `[...slug].astro` page component to use the `'published'` variant instead of the `'draft'` variant depending on the build environment.

Reasoning:
When I was trying out this example for the first time, I couldn't get why I got a `401 Unauthorized` error when building with a `public` token in my prod environment. This PR fixes that